### PR TITLE
Possibility to use self-signed certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,6 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+local-install: clean ## install the package to the active user Python's site-packages
+	python setup.py install --user

--- a/dkron/api.py
+++ b/dkron/api.py
@@ -7,12 +7,13 @@ class DkronException(Exception):
 
 
 class Dkron():
-    def __init__(self, hosts):
+    def __init__(self, hosts, verify):
         self.raise_errors = True
         self.base_url = None
         for host in hosts:
             try:
                 self.base_url = host
+                self.verify = verify
                 self.get_status()
                 break
             except DkronException as ex:
@@ -36,45 +37,45 @@ class Dkron():
 
     def get_status(self):
         url = self._get_url('/v1')
-        response = requests.get(url, headers=self._get_headers(), timeout=20)
+        response = requests.get(url, headers=self._get_headers(), timeout=20, verify = self.verify)
         return self._process_response(response)
 
     def get_leader(self):
         url = self._get_url('/v1/leader')
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def get_members(self):
         url = self._get_url('/v1/members')
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def get_jobs(self):
         url = self._get_url('/v1/jobs')
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def get_job(self, name):
         url = self._get_url('/v1/jobs/%s' % name)
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def apply_job(self, data):
         url = self._get_url('/v1/jobs')
-        response = requests.post(url, headers=self._get_headers(), json=data)
+        response = requests.post(url, headers=self._get_headers(), json=data, verify = self.verify)
         return self._process_response(response)
 
     def run_job(self, name):
         url = self._get_url('/v1/jobs/%s' % name)
-        response = requests.post(url, headers=self._get_headers())
+        response = requests.post(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def delete_job(self, name):
         url = self._get_url('/v1/jobs/%s' % name)
-        response = requests.delete(url, headers=self._get_headers())
+        response = requests.delete(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)
 
     def get_executions(self, job_name):
         url = self._get_url('/v1/executions/%s' % job_name)
-        response = requests.get(url, headers=self._get_headers())
+        response = requests.get(url, headers=self._get_headers(), verify = self.verify)
         return self._process_response(response)

--- a/dkron/cli.py
+++ b/dkron/cli.py
@@ -11,8 +11,9 @@ api = None
 
 
 @click.group(context_settings=_CONTEXT_SETTINGS)
-@click.option('--hosts', help='Dkron instance URLs, separated with commans', envvar=_DKRON_ENV_NAME_HOSTS)
-def cli(hosts):
+@click.option('--hosts', help='Dkron instance URLs, separated with commas', envvar=_DKRON_ENV_NAME_HOSTS)
+@click.option('--secure/--insecure', ' /-k', help='Do not verify the servers TLS certificate.', is_flag=True, default=True)
+def cli(hosts, secure):
     '''
     Command line interface client for Dkron
     '''
@@ -21,7 +22,7 @@ def cli(hosts):
         print('You must provide %s environment variable OR --hosts option' % _DKRON_ENV_NAME_HOSTS)
         print('Check docs: https://github.com/Eyjafjallajokull/dkron-python#cli-usage')
         exit(1)
-    api = Dkron(hosts.split(','))
+    api = Dkron(hosts.split(','), verify=secure)
 
 
 @cli.group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ appdirs==1.4.0
 click==6.7
 packaging==16.8
 pyparsing==2.1.10
-requests==2.13.0
+requests==2.20.0
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-appdirs==1.4.0
-click==6.7
-packaging==16.8
-pyparsing==2.1.10
-requests==2.20.0
-six==1.10.0
+appdirs>=1.4.0
+click>=6.7
+packaging>=16.8
+pyparsing>=2.1.10
+requests>=2.20.0
+six>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-from pypandoc import convert
+from pypandoc import convert_file
 
 __version__ = '0.0.5'
 
@@ -9,7 +9,7 @@ here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
 try:
-    long_description = convert('README.md', 'rst')
+    long_description = convert_file('README.md', 'rst')
 except(IOError, ImportError):
     with open(path.join(here, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from os import path
 from pypandoc import convert_file
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
In our company, dkron is located on a server with a self signed certificate.
This change allows an insecure connection to be passed using the `verify=False` option within `requests.get`.